### PR TITLE
 Update 1.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ requirements:
   host:
     - python
     - pip
+    - wheel
   run:
     - python
     - h11 >=0.9.0,<1.0
@@ -42,7 +43,7 @@ about:
     This repository does not provide a parsing layer, a network layer, or any rules about concurrency.
     Instead, it’s a purely in-memory solution, defined in terms of data actions and WebSocket frames.
     RFC6455 and Compression Extensions for WebSocket via RFC7692 are fully supported.
-  doc_url: https://wsproto.readthedocs.io/en/latest/
+  doc_url: https://wsproto.readthedocs.io/
   dev_url: https://github.com/python-hyper/wsproto
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,15 +10,15 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
   run:
-    - python >=3.7
+    - python
     - h11 >=0.9.0,<1.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<38]
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,10 @@ requirements:
 test:
   imports:
     - wsproto
+    - wsproto.connection
+    - wsproto.extensions
+    - wsproto.frame_protocol
+    - wsproto.handshake
   commands:
     - pip check
   requires:


### PR DESCRIPTION
## ☆ Wsproto 1.2.0 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5577)
[Upstream](https://github.com/python-hyper/wsproto/blob/1.2.0/setup.py)

### Changes
 - Updated version number and sha256
- Incorporated `wsproto` upstream  testing suite to tests