### PR TITLE
wsproto 1.3.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,29 +1,31 @@
-{% set version = "1.2.0" %}
+{% set name = "wsproto" %}
+{% set version = "1.3.1" %}
 
 package:
-  name: wsproto
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/w/wsproto/wsproto-{{ version }}.tar.gz
-  sha256: ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 81529992325c28f0d9b86ca66fc973da96eb80ab53410249ce2e502749c7723c
 
 build:
   number: 0
-  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
+  skip: True  # [py<310]
 
 requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
+    - setuptools >=77
   run:
     - python
-    - h11 >=0.9.0,<1.0
+    - h11 >=0.16.0,<1
 
 test:
+  source_files:
+    - tests
   imports:
     - wsproto
     - wsproto.connection
@@ -32,10 +34,14 @@ test:
     - wsproto.handshake
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
+    - pytest >=8.3.3,<9
+    - hypothesis >=6.119.4,<7
+
 about:
-  home: https://github.com/python-hyper/wsproto/
+  home: https://github.com/python-hyper/wsproto
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -48,7 +54,7 @@ about:
     This repository does not provide a parsing layer, a network layer, or any rules about concurrency.
     Instead, it’s a purely in-memory solution, defined in terms of data actions and WebSocket frames.
     RFC6455 and Compression Extensions for WebSocket via RFC7692 are fully supported.
-  doc_url: https://wsproto.readthedocs.io/
+  doc_url: https://wsproto.readthedocs.io
   dev_url: https://github.com/python-hyper/wsproto
 
 extra:


### PR DESCRIPTION
wsproto 1.3.1 

**Destination channel:** Defaults

### Links

- [PKG-10761]
- dev_url:        https://github.com/python-hyper/wsproto/tree/1.3.1
- conda_forge:    https://github.com/conda-forge/wsproto-feedstock
- pypi:           https://pypi.org/project/wsproto/1.3.1
- pypi inspector: https://inspector.pypi.io/project/wsproto/1.3.1

### Explanation of changes:

- new version number


[PKG-10761]: https://anaconda.atlassian.net/browse/PKG-10761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ